### PR TITLE
Add support for TAILSCALE_EXTRA_ARGS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Other ENV vars that can be set:
 | `DISABLE_TAILSCALE` | (default: unset), `false`, `true` | Prevents tailscale from starting on dyno boot. |
 | `TAILSCALE_PROXY_PORT` | (default: 1055), any number | If you want / need to configure the internal port that tailscale uses for the SOCKS proxy it sets up. |
 | `TAILSCALE_HOSTNAME` | (default: heroku-app), short text | Text label used to identify your heroku dynos in your tailscale dashboard |
+| `TAILSCALE_EXTRA_ARGS` | (default: unset), short text | Additional arguments to the `tailscale up` command. Useful for passing `--accept-routes` or `--advertise-tags="tag:heroku-dyno"` if you're using an OAuth token vs. a personal access token |
 
 On Dyno startup, if `DISABLE_TAILSCALE` is set to "true" (or any value
 other than false or unset), this buildpack will startup `tailscaled` in

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Other ENV vars that can be set:
 | `DISABLE_TAILSCALE` | (default: unset), `false`, `true` | Prevents tailscale from starting on dyno boot. |
 | `TAILSCALE_PROXY_PORT` | (default: 1055), any number | If you want / need to configure the internal port that tailscale uses for the SOCKS proxy it sets up. |
 | `TAILSCALE_HOSTNAME` | (default: heroku-app), short text | Text label used to identify your heroku dynos in your tailscale dashboard |
-| `TAILSCALE_EXTRA_ARGS` | (default: unset), short text | Additional arguments to the `tailscale up` command. Useful for passing `--accept-routes` or `--advertise-tags="tag:heroku-dyno"` if you're using an OAuth token vs. a personal access token |
+| `TAILSCALE_EXTRA_ARGS` | (default: unset), short text | Additional arguments to the `tailscale up` command. Useful for passing `--accept-routes` or `--advertise-tags="tag:heroku-dyno"` if you're using an [OAuth token](https://tailscale.com/kb/1215/oauth-clients) vs. a personal access token |
+
+If you're using an OAuth token, be sure to consult [the scopes documentation](https://tailscale.com/kb/1215/oauth-clients#scopes) and descriptions to determine what are the most appropriate scopes for your use case. For most use cases, you will _at least_ need the `devices` scope in order for your heroku dynos to register themselves as devices and read the list of other devices on your tailnet.
 
 On Dyno startup, if `DISABLE_TAILSCALE` is set to "true" (or any value
 other than false or unset), this buildpack will startup `tailscaled` in

--- a/bin/start_tailscale.sh
+++ b/bin/start_tailscale.sh
@@ -19,6 +19,7 @@ else
     rm "$PIDFILE"
   fi
 
+  echo "Starting tailscaled" | prefix
   /app/bin/tailscaled \
     --tun=userspace-networking \
     --socks5-server=localhost:"$TAILSCALE_PROXY_PORT" \
@@ -31,7 +32,10 @@ else
 
   trap 'echo "Shutting down" | prefix; kill -9 $TAILSCALE_PID; rm $PIDFILE' SIGTERM
 
-  /app/bin/tailscale up --authkey="$TAILSCALE_AUTHKEY" --hostname="$TAILSCALE_HOSTNAME" --accept-routes
+  # TAILSCALE_EXTRA_ARGS can be used to pass additional arguments to the `tailscale up` command
+  # If you're using an OAUTH token for your authkey, you can use this variable to pass --advertise-tags="tag:heroku-dyno".
+  # Another use for this variable could be to pass --accept-routes so that your heroku dynos can accept routes from subnet routers.
+  bash -c "/app/bin/tailscale up --authkey=$TAILSCALE_AUTHKEY --hostname=$TAILSCALE_HOSTNAME $TAILSCALE_EXTRA_ARGS"
 
   export ALL_PROXY=socks5://localhost:"$TAILSCALE_PROXY_PORT"
   export HTTP_PROXY=http://localhost:"$TAILSCALE_PROXY_PORT"


### PR DESCRIPTION
Recently I started looking into what it would take to make this build pack support using a Tailscale OAuth token (which doesn't expire, and comes with explicit API constraints) as opposed to the personal API token (which expires at most every 90 days, and comes with no explicit API constraints).

As it happens, it looks like you can pass an OAuth key instead of a personal API token to the `--authkey` flag, no problem. The trick is, if you pass an OAuth key, you _also_ need to pass the list of tags you want associated with this machine via the `--advertise-tags` flag.

Separately, I noticed while watching [this YouTube video](https://www.youtube.com/watch?v=tqvvZhGrciQ) and reading [this docs article](https://tailscale.com/kb/1282/docker) about using Tailscale with docker that the official Tailscale docker image accepts a `TS_EXTRA_ARGS` env var for passing additional flags to the `tailscale command`.

That seems like a good way to handle this for us, as well. The Tailscale docker image passes values from the `TS_EXTRA_ARGS` variable to the `tailscale set` as opposed to what I'm doing here (ie - interpolating them into the `tailscale up` command string). I'm on the fence about whether or not that's a better approach than what I've got here.