### PR TITLE
Change install strategy entirely

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,28 +1,95 @@
 #!/bin/bash
 
+set -e
+
 BUILD_DIR=$1
-#CACHE_DIR=$2
+CACHE_DIR=$2
 ENV_DIR=$3
 BUILDPACK_DIR="$(dirname "$(dirname "$0")")"
+
+function main() {
+  export_env_dir "$ENV_DIR"
+
+  # Get latest stable version from the tailscale pkgs page
+  TAILSCALE_VERSION=${TAILSCALE_VERSION:-$(curl --silent https://pkgs.tailscale.com/stable/ | \
+    awk '/option/ {gsub("<[^>]+>", ""); print $1}' | \
+    grep -v latest | sort -r | head -1)}
+
+  # if we have a cached copy of the tailscale executable...
+  if [ -f "$CACHE_DIR/tailscale" ]; then
+    cached_version=$("$CACHE_DIR/tailscale" --version | head -1)
+
+    # ...and the cached version matches the requested version.
+    if [ "$cached_version" = "$TAILSCALE_VERSION" ]; then
+      echo "Installing Tailscale v$TAILSCALE_VERSION from cache" | major
+      copy_binaries_from_cache
+    fi
+  fi
+
+  if [ ! -f "$BUILD_DIR/bin/tailscale" ]; then
+    echo "Installing Tailscale v$TAILSCALE_VERSION" | major
+    install_from_apt
+    copy_binaries_to_cache
+    copy_binaries_from_cache
+  fi
+
+  copy_start_script
+  echo "Tailscale installed" | major
+  echo
+}
 
 function indent() {
   sed -u 's/^/       /'
 }
 
-if [[ ! -e "$ENV_DIR/TAILSCALE_AUTHKEY" ]]; then
-  echo "error: must set TAILSCALE_AUTHKEY variable in order to move forward"
-  exit 1
-fi
+function major() {
+  sed -u 's/^/-----> /'
+}
 
-# load stack-appropriate versions of the tailscale binaries into /app/bin
-echo "Installing tailscale binaries" | indent
-mkdir -p "$BUILD_DIR"/bin
-tar -xzf "$BUILDPACK_DIR/$STACK.tgz" -C "$BUILD_DIR"/bin
+export_env_dir() {
+  env_dir=$1
+  acceptlist_regex=${2:-''}
+  denylist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
+  if [ -d "$env_dir" ]; then
+    # shellcheck disable=SC2045
+    for e in $(ls $env_dir); do
+      echo "$e" | grep -E "$acceptlist_regex" | grep -qvE "$denylist_regex" &&
+      export "$e=$(cat $env_dir/$e)"
+      :
+    done
+  fi
+}
 
-# Copy the tailscale start script to the .profile.d directory
-echo "Copying tailscale start script" | indent
-mkdir -p "$BUILD_DIR"/.profile.d
-cp "$BUILDPACK_DIR"/bin/start_tailscale.sh "$BUILD_DIR"/.profile.d/tailscale.sh
+function copy_binaries_from_cache() {
+  echo "Copying tailscale binaries to $BUILD_DIR/bin" | indent
+  mkdir -p "$BUILD_DIR"/bin
+  cp "$CACHE_DIR/tailscale" "$BUILD_DIR/bin/tailscale"
+  cp "$CACHE_DIR/tailscaled" "$BUILD_DIR/bin/tailscaled"
+}
 
-echo "-----> Tailscale installed"
-echo
+function copy_binaries_to_cache() {
+  cp /usr/bin/tailscale "$CACHE_DIR/tailscale"
+  cp /usr/sbin/tailscaled "$CACHE_DIR/tailscaled"
+}
+
+function install_from_apt() {
+  # load the VERSION_CODENAME ENV var from the OS.
+  . /etc/os-release
+
+  # shellcheck disable=SC2069
+  {
+    curl --silent "https://pkgs.tailscale.com/stable/ubuntu/$VERSION_CODENAME.noarmor.gpg" | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+    curl --silent "https://pkgs.tailscale.com/stable/ubuntu/$VERSION_CODENAME.tailscale-keyring.list" | tee /etc/apt/sources.list.d/tailscale.list
+
+    apt-get update
+    apt-get install -y tailscale="$TAILSCALE_VERSION" tailscale-archive-keyring
+  } 2>&1 >/dev/null
+}
+
+function copy_start_script() {
+  echo "Copying tailscale start script" | indent
+  mkdir -p "$BUILD_DIR"/.profile.d
+  cp "$BUILDPACK_DIR"/bin/start_tailscale.sh "$BUILD_DIR"/.profile.d/tailscale.sh
+}
+
+main

--- a/bin/compile
+++ b/bin/compile
@@ -90,10 +90,7 @@ function install_from_apt() {
   mkdir -p "$APT_SOURCELIST_DIR"   # make dir for sources
 
   if [ ! "$(whoami)" = "heroku" ]; then
-    {
-      chown -Rv _apt:"$(whoami)" "$APT_CACHE_DIR/archives/partial/"
-      chmod -Rv 700 "$APT_CACHE_DIR/archives/partial/"
-    } 2>&1 | indent
+    chmod -Rv 777 "$APT_CACHE_DIR/archives/partial/" 2>&1 | indent
   fi
 
   cp -R "/usr/share/keyrings" "$APT_KEYRINGS_DIR"

--- a/bin/compile
+++ b/bin/compile
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
 BUILD_DIR=$1
 CACHE_DIR=$2
@@ -11,9 +12,7 @@ function main() {
   export_env_dir "$ENV_DIR"
 
   # Get latest stable version from the tailscale pkgs page
-  TAILSCALE_VERSION=${TAILSCALE_VERSION:-$(curl --silent https://pkgs.tailscale.com/stable/ | \
-    awk '/option/ {gsub("<[^>]+>", ""); print $1}' | \
-    grep -v latest | sort -r | head -1)}
+  TAILSCALE_VERSION=${TAILSCALE_VERSION:-$("$BUILDPACK_DIR"/bin/tailscale_versions.sh | sort -r | head -1)}
 
   # if we have a cached copy of the tailscale executable...
   if [ -f "$CACHE_DIR/tailscale" ]; then
@@ -62,28 +61,68 @@ export_env_dir() {
 
 function copy_binaries_from_cache() {
   echo "Copying tailscale binaries to $BUILD_DIR/bin" | indent
-  mkdir -p "$BUILD_DIR"/bin
+  mkdir -p "$BUILD_DIR/bin"
   cp "$CACHE_DIR/tailscale" "$BUILD_DIR/bin/tailscale"
   cp "$CACHE_DIR/tailscaled" "$BUILD_DIR/bin/tailscaled"
 }
 
 function copy_binaries_to_cache() {
-  cp /usr/bin/tailscale "$CACHE_DIR/tailscale"
-  cp /usr/sbin/tailscaled "$CACHE_DIR/tailscaled"
+  cp "$APT_CACHE_DIR/tailscale/usr/bin/tailscale" "$CACHE_DIR/tailscale"
+  cp "$APT_CACHE_DIR/tailscale/usr/sbin/tailscaled" "$CACHE_DIR/tailscaled"
 }
 
 function install_from_apt() {
   # load the VERSION_CODENAME ENV var from the OS.
   . /etc/os-release
 
+  APT_CACHE_DIR="$HOME/apt/cache"
+  APT_STATE_DIR="$HOME/apt/state"
+  APT_KEYRINGS_DIR="$HOME/apt/keyrings"
+  APT_SOURCELIST_DIR="$HOME/apt/sources"   # place custom sources.list here
+  APT_SOURCEPARTS_DIR="$APT_SOURCELIST_DIR/sources.list.d"
+  APT_SOURCES="$APT_SOURCELIST_DIR/sources.list"
+
+  rm -rf "${CACHE_DIR}/apt"
+  mkdir -p "$CACHE_DIR/apt"
+  mkdir -p "$APT_CACHE_DIR"
+  mkdir -p "$APT_CACHE_DIR/archives/partial"
+  mkdir -p "$APT_STATE_DIR/lists/partial"
+  mkdir -p "$APT_SOURCELIST_DIR"   # make dir for sources
+
+  if [ ! "$(whoami)" = "heroku" ]; then
+    {
+      chown -Rv _apt:"$(whoami)" "$APT_CACHE_DIR/archives/partial/"
+      chmod -Rv 700 "$APT_CACHE_DIR/archives/partial/"
+    } 2>&1 | indent
+  fi
+
+  cp -R "/usr/share/keyrings" "$APT_KEYRINGS_DIR"
+
+  cat "/etc/apt/sources.list" > "$APT_SOURCES"    # no cp here
+  cp -R "/etc/apt/sources.list.d" "$APT_SOURCEPARTS_DIR"
+
+  APT_OPTIONS=("-o" "debug::nolocking=true" "-o" "dir::cache=$APT_CACHE_DIR" "-o" "dir::state=$APT_STATE_DIR")
+  # Override the use of /etc/apt/sources.list (sourcelist) and /etc/apt/sources.list.d/* (sourceparts).
+  APT_OPTIONS+=("-o" "dir::etc::sourcelist=$APT_SOURCES" "-o" "dir::etc::sourceparts=$APT_SOURCEPARTS_DIR")
+  APT_OPTIONS+=("--allow-downgrades" "--allow-remove-essential" "--allow-change-held-packages")
+
   # shellcheck disable=SC2069
   {
-    curl --silent "https://pkgs.tailscale.com/stable/ubuntu/$VERSION_CODENAME.noarmor.gpg" | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
-    curl --silent "https://pkgs.tailscale.com/stable/ubuntu/$VERSION_CODENAME.tailscale-keyring.list" | tee /etc/apt/sources.list.d/tailscale.list
+    TS_KEYFILE="$APT_KEYRINGS_DIR/tailscale-archive-keyring.gpg"
+    TS_SOURCEFILE="$APT_SOURCEPARTS_DIR/tailscale.list"
+    curl --silent "https://pkgs.tailscale.com/stable/ubuntu/$VERSION_CODENAME.noarmor.gpg" > "$TS_KEYFILE"
+    curl --silent "https://pkgs.tailscale.com/stable/ubuntu/$VERSION_CODENAME.tailscale-keyring.list" > "$TS_SOURCEFILE-raw"
 
-    apt-get update
-    apt-get install -y tailscale="$TAILSCALE_VERSION" tailscale-archive-keyring
-  } 2>&1 >/dev/null
+    # deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/ubuntu noble main
+    awk "{sub(\"signed-by=[^\]]+\", \"signed-by=$TS_KEYFILE\"); print}" "$TS_SOURCEFILE-raw" > "$TS_SOURCEFILE"
+    rm "$TS_SOURCEFILE-raw"
+
+    apt-get "${APT_OPTIONS[@]}" update
+    apt-get "${APT_OPTIONS[@]}" -y -d install tailscale="$TAILSCALE_VERSION" tailscale-archive-keyring
+    for DEB in "$APT_CACHE_DIR/archives/tailscale"*.deb; do
+      dpkg -x "$DEB" "$APT_CACHE_DIR/tailscale/"
+    done
+  } 2>&1 | indent
 }
 
 function copy_start_script() {

--- a/bin/start_tailscale.sh
+++ b/bin/start_tailscale.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 function prefix() {
   sed -u 's/^/[tailscale] /'
 }
@@ -23,6 +25,8 @@ else
     --tun=userspace-networking \
     --socks5-server=localhost:"$TAILSCALE_PROXY_PORT" \
     --outbound-http-proxy-listen=localhost:"$TAILSCALE_PROXY_PORT" \
+    --socket=/tmp/tailscaled.sock \
+    --state=/tmp/tailscale \
     --verbose=0 \
   2>&1 | prefix >/dev/null &
 
@@ -31,7 +35,19 @@ else
 
   trap 'echo "Shutting down" | prefix; kill -9 $TAILSCALE_PID; rm $PIDFILE' SIGTERM
 
-  /app/bin/tailscale up --authkey="$TAILSCALE_AUTHKEY" --hostname="$TAILSCALE_HOSTNAME" --accept-routes
+  # Unfortunately, tailscale does not have an ENV var or global setting mechanism
+  # that we can use to configure the --socket setting for the tailscale command. 
+  # As a band-aid for this, the following creates a relatively simple alias that
+  # adds the --socket setting by default. This means users of this buildpack won't
+  # need to have to remember to mention this socket file in their invokations.
+  mv /app/bin/tailscale /app/bin/tailscale-orig
+  cat <<-EOF > /app/bin/tailscale
+#!/bin/bash
+/app/bin/tailscale-orig --socket=tmp/tailscaled.sock "\$@"
+EOF
+  chmod +x /app/bin/tailscale
+
+  /app/bin/tailscale up --auth-key="$TAILSCALE_AUTHKEY" --hostname="$TAILSCALE_HOSTNAME" --accept-routes
 
   export ALL_PROXY=socks5://localhost:"$TAILSCALE_PROXY_PORT"
   export HTTP_PROXY=http://localhost:"$TAILSCALE_PROXY_PORT"

--- a/bin/start_tailscale.sh
+++ b/bin/start_tailscale.sh
@@ -43,7 +43,7 @@ else
   mv /app/bin/tailscale /app/bin/tailscale-orig
   cat <<-EOF > /app/bin/tailscale
 #!/bin/bash
-/app/bin/tailscale-orig --socket=tmp/tailscaled.sock "\$@"
+/app/bin/tailscale-orig --socket=/tmp/tailscaled.sock "\$@"
 EOF
   chmod +x /app/bin/tailscale
 

--- a/bin/tailscale_versions.sh
+++ b/bin/tailscale_versions.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+curl --silent https://pkgs.tailscale.com/stable/ | \
+  awk '/option/ {gsub("<[^>]+>", ""); print $1}' | \
+  grep -v latest | sort

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+# Usage:
+# [STACK=22 TAILSCALE_AUTHKEY=tskey-asdlfkjasdf ENV-KEY=value ENV-KEY=value] ./bin/test [-d -C]
+#
+# Flags:
+# -d - Debug mode. In Debug mode, the script will drop you into a bash shell
+#      inside the running container so that you can inspect the Environment
+#      before it is stopped.
+#
+# -C - Reset Build Cache. By default, the test script simulates the heroku
+#      build cache. Passing -C resets that cache.
+#
+# Environment Variables:
+# - STACK defaults to the latest stack version this buildpack supports
+# - TAILSCALE_AUTHKEY is the only required argument
+# 
+# Any other buildpack-related ENV vars can be set along with the invocation of the test script.
+# - TAILSCALE_VERSION
+# - TAILSCALE_EXTRA_ARGS
+# - TAILSCALE_HOSTNAME
+# - TAILSCALE_PROXY_PORT
+# - DISABLE_TAILSCALE
+#
+# Examples:
+# STACK=20 TAILSCALE_AUTHKEY=12345 DISABLE_TAILSCALE=true ./bin/test
+# STACK=22 TAILSCALE_AUTHKEY=12345 TAILSCALE_PROXY_PORT=1011 ./bin/test
+
+function announce() {
+  echo "$1" | tr '[:lower]' '[:upper]' | awk '{print "\n" $0; gsub(".", "="); print $0}'
+}
+
+args=$(getopt dC "$@")
+# shellcheck disable=SC2181
+if [[ $? -ne 0 ]]; then
+  exit 1;
+fi
+
+DEBUG=0
+NOCACHE=0;
+
+eval set -- "$args"
+
+while :; do
+  case "$1" in
+    -d) # open a debug session inside the container
+      DEBUG=1;
+      shift;
+      ;;
+    -C) # delete the cache folder
+      NOCACHE=1;
+      shift;
+      ;;
+    --)
+      shift;
+      break
+      ;;
+  esac
+done
+
+set -eo pipefail
+
+[ -z "$TAILSCALE_AUTHKEY" ] && echo "No TAILSCALE_AUTHKEY set" && exit 1
+
+STACK=${STACK:-22}
+APP_DIR="./tmp/app"
+ENV_DIR="./tmp/env"
+
+# get latest tailscale version if one hasn't been set explicitly
+tailscale_version=${TAILSCALE_VERSION:-$(curl --silent https://pkgs.tailscale.com/stable/ | \
+  awk '/option/ {gsub("<[^>]+>", ""); print $1}' | \
+  grep -v latest | sort -r | head -1)}
+
+# set the cache dir for our current stack and tailscale version
+CACHE_DIR="./tmp/cache/heroku-$STACK/${tailscale_version:-latest}"
+
+# setup local directories that will be mounted into the container as build context
+[ "$NOCACHE" -gt 0 ] && rm -rf "$CACHE_DIR"
+rm -rf "$APP_DIR" "$ENV_DIR"
+mkdir -p "$CACHE_DIR" "$APP_DIR" "$ENV_DIR"
+
+# Create a temporary env file to pass to the docker run command
+# The envfile should only contain variables that have been explicitly set when calling this script
+envfile=$(mktemp)
+echo "STACK=heroku-$STACK" >> "$envfile"
+
+# This is the full list of supported ENV vars for this buildpack.
+vars=$(cat<<-EOVARS
+TAILSCALE_AUTHKEY
+TAILSCALE_VERSION
+TAILSCALE_EXTRA_ARGS
+TAILSCALE_HOSTNAME
+TAILSCALE_PROXY_PORT
+DISABLE_TAILSCALE
+EOVARS
+)
+
+# For each of the above vars..
+for var in $vars; do
+  # if the var is set...
+  if [[ -n "${!var}" ]]; then
+    # ...add it to the envfile...
+    echo "$var=${!var}" >> "$envfile"
+
+    # ...add write it out as a file in the ENV dir
+    echo "${!var}" > "$ENV_DIR/$var"
+  fi
+done
+
+announce "Setting up environment"
+
+# Start a docker container that will be the context that we run all of our tests.
+# Note that we're mounting our current buildpack directory to a directory inside
+# the container at /buildpack. The return value of the `docker run` command is the
+# id of the started container which we save so that we can use it in subsequent
+# docker commands.
+id=$(docker run \
+  --rm -dit \
+  --user=root \
+  --platform=linux/amd64 \
+  -v .:/buildpack \
+  -v ./tmp/env:/env \
+  -v ./tmp/app:/app \
+  -v "$CACHE_DIR":/cache \
+  -e DEBIAN_FRONTEND="noninteractive" \
+  --env-file="$envfile" \
+  "heroku/heroku:$STACK" bash)
+
+function cleanup() {
+  rm "$envfile"
+  docker exec "$id" /app/bin/tailscale logout # ensures we don't leave machines hanging around in our tailscale account
+  docker kill "$id" >/dev/null # kills the container
+  rm -rf ./tmp/{env,app} # cleans up our tmp directories
+}
+
+trap cleanup EXIT
+
+# Install curl in the container if it's not there already.
+# This is only really necessary if we're using the base ubuntu image, rather than heroku/heroku
+docker exec "$id" bash -c "if ! which curl >/dev/null; then apt-get update -y 2>&1>/dev/null && apt-get install -yy curl 2>&1>/dev/null; fi"
+
+# These two steps replicate what happens when Heroku is loading a buildpack
+# during their build phase.
+announce "Build Phase"
+docker exec "$id" bash /buildpack/bin/detect /app
+docker exec "$id" bash /buildpack/bin/compile /app /cache /env
+
+# In this buildpack's compile stage, we write out a file for starting tailscale
+# when new containers start up. We'll just call that file directly here.
+announce "Run Phase"
+docker exec "$id" bash /app/.profile.d/tailscale.sh
+
+# This is where we run our tests.
+# Currently we write out the tailscale version, and the result of `tailscale status` filtered
+# to the IP of the currently running container.
+announce "Test Output"
+script=$(cat <<EOF
+  ts_version=\$(/app/bin/tailscale --version | head -1)
+  ip=\$(/app/bin/tailscale ip | head -1)
+  status=\$(/app/bin/tailscale status | grep \$ip)
+
+echo "Tailscale Version: \$ts_version"
+echo "Tailscale Status: \$status"
+EOF
+)
+docker exec "$id" bash -c "$script"
+
+if [ $DEBUG -gt 0 ]; then
+  echo
+  echo "[DEBUG] Logging you into running container..."
+  docker exec -it "$id" bash
+fi

--- a/bin/test
+++ b/bin/test
@@ -27,7 +27,7 @@
 # STACK=22 TAILSCALE_AUTHKEY=12345 TAILSCALE_PROXY_PORT=1011 ./bin/test
 
 function announce() {
-  echo "$1" | tr '[:lower]' '[:upper]' | awk '{print "\n" $0; gsub(".", "="); print $0}'
+  echo "$1" | awk '{print "\n" $0; gsub(".", "="); print $0}'
 }
 
 args=$(getopt dC "$@")
@@ -67,15 +67,17 @@ APP_DIR="./tmp/app"
 ENV_DIR="./tmp/env"
 
 # get latest tailscale version if one hasn't been set explicitly
-tailscale_version=${TAILSCALE_VERSION:-$(curl --silent https://pkgs.tailscale.com/stable/ | \
-  awk '/option/ {gsub("<[^>]+>", ""); print $1}' | \
-  grep -v latest | sort -r | head -1)}
-
+# note that I'm changing this variable name to lower case so that the uppercase
+# version does not get overwritten. This is so that below we don't end up injecting
+# this environment variable into the build environment unless it's been set externally.
+# This is so that we can test what happens in the build environment when TAILSCALE_VERSION
+# is unset.
+tailscale_version=${TAILSCALE_VERSION:-$(./bin/tailscale_versions.sh | sort -r | head -1)}
 # set the cache dir for our current stack and tailscale version
 CACHE_DIR="./tmp/cache/heroku-$STACK/${tailscale_version:-latest}"
 
 # setup local directories that will be mounted into the container as build context
-[ "$NOCACHE" -gt 0 ] && rm -rf "$CACHE_DIR"
+[ "$NOCACHE" -gt 0 ] && announce "Clearing cache" && rm -rf "$CACHE_DIR"
 rm -rf "$APP_DIR" "$ENV_DIR"
 mkdir -p "$CACHE_DIR" "$APP_DIR" "$ENV_DIR"
 
@@ -116,7 +118,6 @@ announce "Setting up environment"
 # docker commands.
 id=$(docker run \
   --rm -dit \
-  --user=root \
   --platform=linux/amd64 \
   -v .:/buildpack \
   -v ./tmp/env:/env \
@@ -127,13 +128,18 @@ id=$(docker run \
   "heroku/heroku:$STACK" bash)
 
 function cleanup() {
+  announce "Cleaning up"
   rm "$envfile"
   docker exec "$id" /app/bin/tailscale logout # ensures we don't leave machines hanging around in our tailscale account
   docker kill "$id" >/dev/null # kills the container
   rm -rf ./tmp/{env,app} # cleans up our tmp directories
+  echo "Done."
 }
 
+# run cleanup no matter how this script is exited
 trap cleanup EXIT
+trap cleanup SIGINT
+trap cleanup SIGTERM
 
 # Install curl in the container if it's not there already.
 # This is only really necessary if we're using the base ubuntu image, rather than heroku/heroku
@@ -155,7 +161,7 @@ docker exec "$id" bash /app/.profile.d/tailscale.sh
 # to the IP of the currently running container.
 announce "Test Output"
 script=$(cat <<EOF
-  ts_version=\$(/app/bin/tailscale --version | head -1)
+  ts_version=\$(/app/bin/tailscale version | head -1)
   ip=\$(/app/bin/tailscale ip | head -1)
   status=\$(/app/bin/tailscale status | grep \$ip)
 


### PR DESCRIPTION
This PR changes installation strategy of this buildpack considerably.

### Install at build time, rather than caching assets in this repo

Previously, we built and stored a tarball containing whatever was the latest version of `tailscale` and `tailscaled` at the time for a set list of Heroku stacks. This PR changes the strategy so that we now install tailscale using `apt-get` at build time. A plus of this approach, is that we can now support pinning versions of tailscale. In addition, we use heroku's build cache mechanism to cache the tailscale binaries so that we only incur the "install" the first time we see a new version.

If you do not set the `TAILSCALE_VERSION` environment variable in your app's Heroku ENV, then we will assume you want to install the "latest". We get the "latest" version number directly from tailscale's https://pkgs.tailscale.com/stable/ webpage by parsing the HTML dropdown menu options accordingly.

This makes this buildpack much more flexible, with much less maintenance required.

#### Caveats

**Only supports Heroku stacks version 20+.** In order to support pinning tailscale versions, I couldn't use their one-click install script like I was using previously, as I needed a way to set the desired tailscale version, and that script doesn't (that I can see) have a mechanism for specifying that. Not to mention that the install script handles many more distros than Heroku runs. As such, I pulled out the installation instructions into the compile script directly. The caveat, is that Ubuntu 18.04 and lower used a slightly different verification mechanism than 20.04+, and rather than pulling forward all the conditionals and whatnot to detect this scenario and handle it gracefully, seeing as how Heroku 18 is end-of-life, I decided it'd be easier to just not support that version and lower.

### Testing improvements

This is a significant enough of a change that I wanted to also be able to test this setup more reliably and ensure that it works as expected. As such, this PR also introduces a brand new, and way more robust test script.

The new test script has the following benefits over the previous version:
1. Uses Heroku's [base docker images](https://github.com/heroku/base-images) instead of base ubuntu images. This should provide a much more reliably similar environment to what is run in Heroku by default.
1. Adds a flag (`-d`) for debug mode, which drops you into a bash shell inside the test container after tests have run. This allows you to poke around inside the container and debug the result.
2. Adds a flag (`-C`) for resetting the heroku build cache. As stated above, by default the buildpack will cache the results of installing tailscale in the build cache folder. This flag allows you to reset the cache folder, and test installing from a cold cache.
3. Uses ENV vars to configure the simulated heroku environment. In my other test script PR, these values were passed as arguments to the test script which proved to be pretty brittle, especially since I wanted to be able to support a couple of argument flags that weren't these sorts of envs.

I'm sure there are opportunities to improve on this script even further, but it was extremely helpful for testing out all of these changes and feeling confident that things will work successfully in Heroku's environment.

#### Caveats

**Run our test using root user.** For Heroku 24 they switched to running their containers using the `heroku` user which does not have permission to install software into the container. In the [heroku base images repo's README](https://github.com/heroku/base-images) it acknowledges this and suggests that you do what I'm doing in our test script (switch to root user when you're installing your software additions), but I can't find any documentation anywhere about what user they run buildpack scripts at build time. I'm also not really sure if these base images are what they are using under the hood for buildpack-based deployments either. So, it's possible this whole issue just isn't a thing when running in their normal environment.

Regardless, I will want to run this branch in a test heroku environment for sure before merging to main.

### Cleanup

Lastly, there's a few cleanup commits that are not part of this PR, but that we'll definitely be able to push out into main. Those commits will remove the following files:
- Dockerfile - this was only used for the previous installation strategy.
- ./bin/build - this was the file that used the Dockerfile to create our stack-specific tarballs.
- heroku-*.tgz - these tarballs won't be necessary anymore.

We can also close #2, #3 and #4 without merging. 🎉